### PR TITLE
add window.ZeroMdCssUrls hook for default CSS

### DIFF
--- a/src/zero-md.js
+++ b/src/zero-md.js
@@ -8,7 +8,10 @@ class ZeroMd extends HTMLElement {
   get prismUrl() { return this.getAttribute('prism-url') || 'https://cdn.jsdelivr.net/npm/prismjs@1/prism.min.js'; }
   get cssUrls() {
     let attr = this.getAttribute('css-urls');
-    return attr ? JSON.parse(attr) : ['https://cdn.jsdelivr.net/npm/github-markdown-css@2/github-markdown.min.css', 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism.min.css'];
+    return
+        attr ? JSON.parse(attr)
+      : window.ZeroMdCssUrls ? window.ZeroMdCssUrls
+      : ['https://cdn.jsdelivr.net/npm/github-markdown-css@2/github-markdown.min.css', 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism.min.css'];
   }
 
   connectedCallback() {


### PR DESCRIPTION
## Problem:
There's no current way to set a default theme. You end up having to copy/paste `css-urls="['my-theme.css']"` in to every instance of the element
## Proposed Solution
Expose an optional `ZeroMdCssUrls` hook on the window object

### Some Possible Objections
Pollutes `window`, but then again, there's already ZeroMdStore
### Alternative Solutions
default to a shipped file, (i.e. 'zero-md/defualt-theme.css') tell users to overwrite that file