### PR TITLE
Add support for markdown script children

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ H~~ell~~o *W*o**r**l***d***!
       </xmp>
     </template>
   </zero-md>
+
+  <zero-md>
+    <!-- Or directly use a script tag with type "text/markdown" -->
+    <script type="text/markdown">
+      # Markdown in Script tags is automatically dedented
+      
+      > So you don't have to worry about how much whitespace 
+      > you have to the left of your markdown block
+    </script>
+  </zero-md>
   ```
 
 3. Or pass your own CSS definitions directly into the element.
@@ -428,6 +438,8 @@ Load your theme stylesheets by setting the `css-urls` attribute. Check out the [
 **The `<xmp>` tag is deprecated!**
 
 In short, don't worry about it. Though the tag has been deprecated for 20 years, browser vendors (generally) try their hardest not to break the web. It is still implemented in modern browsers today. It's the only tag that suits such purpose, by allowing true *pre-formatted* content to be written as-is within the confines of the HTML document without endless escaping. Use it.
+
+Alternatively, you can append a `<script type="text/markdown">` element directly to the `<zero-md>` element.
 
 **v1.x is completely different!**
 

--- a/src/zero-md.js
+++ b/src/zero-md.js
@@ -102,8 +102,10 @@
     _getInputs() {
       return new Promise((resolve, reject) => {
         // First try reading from light DOM template
-        let tpl = this.querySelector('template') && this.querySelector('template').content.querySelector('xmp') || false;
-        if (tpl) { resolve(tpl.textContent); return; }
+        let xmp = this.querySelector('template') && this.querySelector('template').content.querySelector('xmp') || false;
+        let script = this.querySelector('script[type="text/markdown"]') || false;
+        if (xmp) {resolve(xmp.textContent);return;}
+        if (script) {resolve(dedent(script.textContent));return;}
         // Next try reading from `src` attribute
         this._ajaxGet(this.src)
           .then(data => resolve(data))
@@ -197,4 +199,10 @@
         });
     }
   });
+  
+  function dedent(str) {
+    str = str.replace(/^\n/, "");
+    let match = str.match(/^\s+/);
+    return match ? str.replace(new RegExp("^"+match[0], "gm"), "") : str;
+  } 
 }(window, document));


### PR DESCRIPTION
(apologies for omitting description and title up till now)

This PR adds support for markdown script children in addition to XMP:


```html
<zero-md>
  <script type="text/markdown">
    # This is my markdown script
    It is automatically dedented
      - so this line, with a src indent of 6, will be parsed as having a markdown indent of 2
  </script>
</zero-md>
``` 

xmp template children will take precedence over script tags 