### PR TITLE
Fix/no shadow dom scrolling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,9 +150,9 @@ export class ZeroMd extends HTMLElement {
   // Scroll to selected element
   goto(id) {
     if (id) {
-      const el = this.root.getElementById
-        ? this.root.getElementById(id.substring(1))
-        : document.getElementById(id.substring(1))
+      const el = this.hasAttribute('no-shadow')
+        ? document.getElementById(id.substring(1))
+        : this.root.getElementById(id.substring(1))
       if (el) {
         el.scrollIntoView()
       }

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,9 @@ export class ZeroMd extends HTMLElement {
   // Scroll to selected element
   goto(id) {
     if (id) {
-      const el = this.root.getElementById(id.substring(1))
+      const el = this.root.getElementById
+        ? this.root.getElementById(id.substring(1))
+        : document.getElementById(id.substring(1))
       if (el) {
         el.scrollIntoView()
       }

--- a/src/index.js
+++ b/src/index.js
@@ -150,9 +150,7 @@ export class ZeroMd extends HTMLElement {
   // Scroll to selected element
   goto(id) {
     if (id) {
-      const el = this.hasAttribute('no-shadow')
-        ? document.getElementById(id.substring(1))
-        : this.root.getElementById(id.substring(1))
+      const el = this.root.querySelector(id)
       if (el) {
         el.scrollIntoView()
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -346,6 +346,19 @@ describe('unit tests', () => {
       assert(f.scrollTop > 0)
       assert(location.hash === '#tamen-et-veri')
     })
+
+    it('hijacks same-doc hash links and scrolls id into view in no-shadow mode', async () => {
+      f = add(
+        `<div style="height:200px;overflow:hidden;"><zero-md src="fixture.md" manual-render no-shadow></zero-md></div>`
+      )
+      const el = f.querySelector('zero-md')
+      await el.render()
+      const a = document.querySelector('a[href="#tamen-et-veri"]')
+      a.click()
+      await sleep(50)
+      assert(f.scrollTop > 0)
+      assert(location.hash === '#tamen-et-veri')
+    })
   })
 
   describe('Mutation Observer tests', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -325,6 +325,15 @@ describe('unit tests', () => {
       assert(f.scrollTop > 0)
     })
 
+    it('scrolls to element if zero-md used in no-shadow mode', async () => {
+      location.hash = 'tamen-et-veri'
+      f = add(
+        `<div style="height:200px;overflow:hidden;"><zero-md src="fixture.md" no-shadow></zero-md></div>`
+      )
+      await sleep(500)
+      assert(f.scrollTop > 0)
+    })
+
     it('hijacks same-doc hash links and scrolls id into view', async () => {
       f = add(
         `<div style="height:200px;overflow:hidden;"><zero-md src="fixture.md" manual-render></zero-md></div>`


### PR DESCRIPTION
closes #82 

I do not really like the implementation of this fix. It is not very simply written.

However, I could not think how to better do it.

Perhaps, we could use `this.hasAttribute('no-shadow')` to check for shadow DOM, then use either `this.root` or `document` based on result. This would be more code, but perhaps more understandable of why it is happening.