### PR TITLE
Adapt example to pass options to Marked

### DIFF
--- a/docs/advanced-usage/readme.md
+++ b/docs/advanced-usage/readme.md
@@ -85,9 +85,11 @@ markdown parser.
 <zero-md id="app" src="example.md" manual-render></zero-md>
 <script>
   // Pass marked opts into render() function
-  app.render({
-    gfm: false,
-    ...
-  })
+  window.onload = function () {
+    app.render({
+      gfm: false,
+      ...
+    })
+  }
 </script>
 ```

--- a/docs/advanced-usage/readme.md
+++ b/docs/advanced-usage/readme.md
@@ -85,11 +85,12 @@ markdown parser.
 <zero-md id="app" src="example.md" manual-render></zero-md>
 <script>
   // Pass marked opts into render() function
-  window.onload = function () {
+  customElements.whenDefined('zero-md').then(() => {
     app.render({
       gfm: false,
       ...
     })
-  }
+  })
 </script>
 ```
+


### PR DESCRIPTION
Hello,

Thanks for your nice library! I went into an issue when trying to pass options to Marked as explained in the documentation (see last section of https://zerodevx.github.io/zero-md/advanced-usage/). I consistently went into "render is not a function" when trying to use this example (maybe it's related to the fact I'm using zero-md as a module? I don't know). I'm not an expert in JS (not at all), but I found that the issue can be solved by delaying the call to render. I don't know why putting "defer" in <script> does not work, but using "window.onload" does... 

This pull request adapts the example provided in the documentation to include this "trick". 

In case it helps :-)