### PR TITLE
Fix KATEX rendering issue

### DIFF
--- a/src/lib/zero-md.js
+++ b/src/lib/zero-md.js
@@ -136,6 +136,7 @@ export default class ZeroMd extends ZeroMdBase {
   }
 
   parseKatex(text = '', opts = {}) {
+    opts.output = 'mathml'
     return this.katex.renderToString(text, { ...opts, throwOnError: false })
   }
 


### PR DESCRIPTION
Issue with KATEX rendering where by default it renders both HTML and MathML which ends up looking like the image attached. Fix is to pass in an option where only MathML is rendered.
<img width="1051" alt="Screenshot 2024-07-20 at 2 44 12 PM" src="https://github.com/user-attachments/assets/69f266f4-5edb-46ca-b863-d29d6e20cf47">
