### PR TITLE
chore: switch marked to min.js

### DIFF
--- a/src/lib/presets.js
+++ b/src/lib/presets.js
@@ -41,7 +41,7 @@ export const STYLES = {
 
 export const LOADERS = {
   marked: async () => {
-    const Marked = await load(jsdelivr('marked@15/lib/marked.esm.js'), 'Marked')
+    const Marked = await load(jsdelivr('marked@15/lib/marked.esm.min.js'), 'Marked')
     return new Marked({ async: true })
   },
   markedBaseUrl: () => load(jsdelivr('marked-base-url@1/+esm'), 'baseUrl'),


### PR DESCRIPTION
Changes `marked` dependency to minified version for JS loading performance improvements. 

<img width="1092" height="333" alt="image" src="https://github.com/user-attachments/assets/0ab9b733-0a5c-4651-8202-d7ddf3b8685f" />

CDNs: 
* original: https://cdn.jsdelivr.net/npm/marked@15/lib/marked.esm.js
* minified: https://cdn.jsdelivr.net/npm/marked@15/lib/marked.esm.min.js
